### PR TITLE
Use subcaption package instead of subfigure

### DIFF
--- a/Final Report/LaTeX Template/ResearchTemplate/mmp.sty
+++ b/Final Report/LaTeX Template/ResearchTemplate/mmp.sty
@@ -21,7 +21,7 @@
 
 % packages for figures
 \usepackage{graphicx}
-\usepackage{subfigure}
+\usepackage{subcaption}
 \usepackage{float}
 
 % package for fonts

--- a/Final Report/LaTeX Template/SETemplate/mmp.sty
+++ b/Final Report/LaTeX Template/SETemplate/mmp.sty
@@ -21,7 +21,7 @@
 
 % packages for figures
 \usepackage{graphicx}
-\usepackage{subfigure}
+\usepackage{subcaption}
 \usepackage{float}
 
 % package for fonts


### PR DESCRIPTION
The `subfigure` package has been deprecated. `subcaption` is now what's commonly used and what all LaTeX guides on the internet refer to.
